### PR TITLE
Add expirationInSeconds configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/evidence-client-js",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "Javascript lib to add evidences to the evidence server",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -49,10 +49,10 @@ class EvidenceClient {
     const hasExpirationArgumentSetting = !isUndefined(expirationInSeconds)
 
     let params = {}
-    if( hasExpirationArgumentSetting ) {
+    if (hasExpirationArgumentSetting) {
       params = { expirationInSeconds }
     } else {
-      if( hasExpirationGlobalSetting ) {
+      if (hasExpirationGlobalSetting) {
         params = { expirationInSeconds: this.expirationInSeconds }
       }
     }
@@ -66,7 +66,7 @@ class EvidenceClient {
       cache: true,
       responseType: 'text',
       headers: {
-        'Content-Type': 'text/plain'
+        'Content-Type': 'text/plain',
       },
       params,
     })

--- a/src/index.js
+++ b/src/index.js
@@ -32,9 +32,10 @@ const EVIDENCE_SERVER_ENDPOINT = '/api/Evidence?application='
 class EvidenceClient {
   config(config) {
     this.request = (!isUndefined(config.request) ? config.request : this.request) || fetchRequest
+    this.expirationInSeconds = config.expirationInSeconds
   }
 
-  sendEvidence(application, evidence) {
+  sendEvidence(application, evidence, expirationInSeconds) {
     if (process.env.NODE_ENV === 'development') {
       return 'development'
     }
@@ -42,6 +43,11 @@ class EvidenceClient {
     let url = EVIDENCE_SERVER_ENDPOINT + application
     const hash = generateEvidenceHash(evidence)
     url = `${url}&hash=${hash}`
+    const params = expirationInSeconds
+      ? { expirationInSeconds }
+      : this.expirationInSeconds
+      ? { expirationInSeconds: this.expirationInSeconds }
+      : {}
 
     this.request({
       url,
@@ -54,6 +60,7 @@ class EvidenceClient {
       headers: {
         'Content-Type': 'text/plain'
       },
+      params,
     })
 
     return hash

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import md5 from 'md5'
 import isUndefined from 'lodash/isUndefined'
+import get from 'lodash/get'
 import isFunction from 'lodash/isFunction'
 import jsonStringifySafe from 'json-stringify-safe'
 
@@ -32,7 +33,7 @@ const EVIDENCE_SERVER_ENDPOINT = '/api/Evidence?application='
 class EvidenceClient {
   config(config) {
     this.request = (!isUndefined(config.request) ? config.request : this.request) || fetchRequest
-    this.expirationInSeconds = config.expirationInSeconds
+    this.expirationInSeconds = get(config, 'expirationInSeconds')
   }
 
   sendEvidence(application, evidence, expirationInSeconds) {
@@ -43,11 +44,18 @@ class EvidenceClient {
     let url = EVIDENCE_SERVER_ENDPOINT + application
     const hash = generateEvidenceHash(evidence)
     url = `${url}&hash=${hash}`
-    const params = expirationInSeconds
-      ? { expirationInSeconds }
-      : this.expirationInSeconds
-      ? { expirationInSeconds: this.expirationInSeconds }
-      : {}
+
+    const hasExpirationGlobalSetting = !isUndefined(this.expirationInSeconds)
+    const hasExpirationArgumentSetting = !isUndefined(expirationInSeconds)
+
+    let params = {}
+    if( hasExpirationArgumentSetting ) {
+      params = { expirationInSeconds }
+    } else {
+      if( hasExpirationGlobalSetting ) {
+        params = { expirationInSeconds: this.expirationInSeconds }
+      }
+    }
 
     this.request({
       url,


### PR DESCRIPTION
Allow an extra parameter to be passed inside the `config` object in the `config` function `expirationInSeconds`.
Allow an extra parameter, named `expirationInSeconds`,  to be passed as the last argument of the `sendEvidence` function

This parameter is used to set up the time to live of the evidence in backend.
`expirationInSeconds `: Number/seconds.

